### PR TITLE
FileUtils dependencies in app/build.gradle

### DIFF
--- a/SimpleTodo/app/build.gradle
+++ b/SimpleTodo/app/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    compile 'commons-io:commons-io:2.4'
 }


### PR DESCRIPTION
Important! FileUtils is in a library called Apache Commons IO which we need to add as a dependency in our app/build.gradle file
https://docs.google.com/presentation/d/15JnmfmFa0hJOEkBhG_TeymChLzDzpOTJvBlOj29A9fY/edit#slide=id.gf45d6347_3_155


   WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
Affected Modules: app

app/build.gradle
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'. 



